### PR TITLE
🐛 Fix `executor.close()` not being run automatically

### DIFF
--- a/examples/fizzbuzz.py
+++ b/examples/fizzbuzz.py
@@ -61,9 +61,6 @@ async def fizz_buzz_test():
     # `results` variable will contain a list of a TestResults
     results = await test_suite.exec(executor)
 
-    # Don't forget to close `executor`.
-    await executor.close()
-
     return results
 
 

--- a/examples/simple_example.py
+++ b/examples/simple_example.py
@@ -47,8 +47,6 @@ async def main():
 
             print(logs)
 
-    await executor.close()
-
 
 if __name__ == '__main__':
     asyncio.run(main())

--- a/runbox/docker/docker_api.py
+++ b/runbox/docker/docker_api.py
@@ -93,6 +93,4 @@ class DockerExecutor:
             if volume:
                 with suppress(DockerError):
                     await volume.delete()
-
-    async def close(self):
-        await self.docker_client.close()
+            await self.docker_client.close()


### PR DESCRIPTION
Made it so that `executor.close()` runs automatically when you exit `executor.workdir()` context manager. I don't see any reason for the `executor` to be closed manually.

All code in /example/ directory runs perfectly with this change. 