### PR TITLE
🐛 Fix readthedocs.io build failure

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -11,4 +11,9 @@ build:
 
 # Build documentation in the docs/ directory with Sphinx
 sphinx:
-   configuration: docs/conf.py
+   configuration: docs/source/conf.py
+
+python:
+  install:
+    - method: pip
+      path: .


### PR DESCRIPTION
Resolve issue #10
Messed around with configuration files to fix all the errors that popped up. It should build without any problems now.

https://runbox-syn-fork.readthedocs.io/en/latest/